### PR TITLE
remove absolute links

### DIFF
--- a/agreements.md
+++ b/agreements.md
@@ -1,5 +1,5 @@
 # Agreements
 
-Agreements are documents which define important processes at Enspiral. They are the legislation which govern the rules of how we operate. The process for creating and changing Agreements is defined in our [Decisions Agreement](https://enspiral.gitbooks.io/enspiral-handbook/content/decisions_agreement.html).
+Agreements are documents which define important processes at Enspiral. They are the legislation which govern the rules of how we operate. The process for creating and changing Agreements is defined in our [Decisions Agreement](decisions_agreement.html).
 
 This page will be updated with more information soon.

--- a/board_agreement.md
+++ b/board_agreement.md
@@ -11,7 +11,7 @@ Enspiral’s goal is to distribute vision, strategy, and leadership as widely as
 ### Roles & Responsibilities
 
 * Ensure Enspiral Foundation Ltd is fully compliant with New Zealand laws and regulations, and its company constitution. 
-* Maintain an overview of current finances, long term financial view, and adequate reserves (as defined in the [Financial Agreement](https://enspiral.gitbooks.io/enspiral-handbook/content/financial_agreement.html)). 
+* Maintain an overview of current finances, long term financial view, and adequate reserves (as defined in the [Financial Agreement](financial_agreement.html)). 
 * Decide what kind of financial activity can go through the Foundation, and oversee activity in the Foundation’s accounts.
 * Oversee all agreements between Enspiral Foundation Ltd and other entities (including Enspiral Ventures and external organisations), such as MOUs, service contracts, fundholding arrangements, etc.
 * Make recommendations about substantive decisions involving Enspiral Foundation Ltd and its assets, consulting with the shareholders and wider network.
@@ -19,7 +19,7 @@ Enspiral’s goal is to distribute vision, strategy, and leadership as widely as
 
 ###Selection & Composition
 
-* Members (shareholders) and existing directors are expected to actively maintain a diverse board in keeping with the [Diversity Agreement](https://enspiral.gitbooks.io/enspiral-handbook/content/diversity_agreement.html).
+* Members (shareholders) and existing directors are expected to actively maintain a diverse board in keeping with the [Diversity Agreement](diversity_agreement.html).
 * Enspiral currently has no quota or strict compositional requirements of the board as we do not want to limit the spectrum of diversity considered.
 * Directors do not need to be Enspiral Members, and the perspectives of non-member directors should be welcomed. 
 

--- a/catalysts.md
+++ b/catalysts.md
@@ -4,7 +4,7 @@ In chemistry, a Catalyst is an agent of change, used in small amounts relative t
 
 With Catalysts at Enspiral, we are attempting to take the function of executive leadership, share it across multiple agents, and cycle many people through the role under a set time limit. The goal is to increase the rate of evolution at Enspiral by reducing friction people encounter trying to make changes and improvements.
 
-You can read more in the [Catalyst Agreement](https://enspiral.gitbooks.io/enspiral-handbook/content/catalyst_agreement.html).
+You can read more in the [Catalyst Agreement](catalyst_agreement.html).
 
 [Loomio reporting thread](https://www.loomio.org/d/kQHzncsJ/catalyst-2-0-playground)
 

--- a/decisions_agreement.md
+++ b/decisions_agreement.md
@@ -15,7 +15,7 @@ For formal decisions, Enspiral uses [consensus decision-making](https://en.wikip
 
 Formal decisions with everyone are only intended to be used when they will have significant impact on the wider network. This Decision Agreement is the core agreement from which all others derive their mandate.
 
-In order to enable efficient decision-making, provide clarity to participants, comply with laws, and protect the network, certain formal decisions are delegated to specific people, groups, or processes other than a consensus decision. This delegation is an Agreement and they are [documented in our Handbook](https://enspiral.gitbooks.io/enspiral-handbook/content/agreements.html). Decisions to change existing Agreements or create new ones are made by everyone in the network together.
+In order to enable efficient decision-making, provide clarity to participants, comply with laws, and protect the network, certain formal decisions are delegated to specific people, groups, or processes other than a consensus decision. This delegation is an Agreement and they are [documented in our Handbook](agreements.html). Decisions to change existing Agreements or create new ones are made by everyone in the network together.
 
 ###Decision Tool: Loomio
 At Enspiral, formal decisions are made using a software tool called [Loomio](http://www.loomio.org), which helps groups make collective decisions using constructive deliberation. This process is based on the principle that diverse perspectives can be synthesised to achieve better solutions that work for more people. 
@@ -54,8 +54,8 @@ Additionally, we have other types of formal decisions for specific circumstances
 
 | Type | Passing Criteria | Engagement Threshold | Minimum Timeframe | Description |
 | -- | -- | -- | -- | -- |
-| Significant Decision | Passes as long as there are no blocks and more than 50% of those stating a position agree | None | 5 working days (10 working days encouraged when possible) | This option should be used for more consequential decisions, such as changes to [Enspiral Agreements](https://enspiral.gitbooks.io/enspiral-handbook/content/agreements.html). |
-| Quorum Decision  | Passes as long as there are no blocks.| Requires at least 75% of all eligible voters to agree or abstain (meaning at least ¾ of all group members must participate) | 5 working days (10 working days encouraged when possible) | This option is used when a Special Resolution (as defined in the [Constitution](https://enspiral.gitbooks.io/enspiral-handbook/content/constitution.html)) is required |
+| Significant Decision | Passes as long as there are no blocks and more than 50% of those stating a position agree | None | 5 working days (10 working days encouraged when possible) | This option should be used for more consequential decisions, such as changes to [Enspiral Agreements](agreements.html). |
+| Quorum Decision  | Passes as long as there are no blocks.| Requires at least 75% of all eligible voters to agree or abstain (meaning at least ¾ of all group members must participate) | 5 working days (10 working days encouraged when possible) | This option is used when a Special Resolution (as defined in the [Constitution](constitution.html)) is required |
 | Emergency Decision | Passes even if there are blocks, but requires 75% of those stating a position to agree | None | 10 working days. If faster action is required, the board can exercise its emergency powers. | This option is a safeguard when the normal decision making processes fails. This option is only used in specific circumstances where a minority block would be destructive, such as removing a member, contributor, catalyst or venture from the community or a role. |
 
 

--- a/financial_agreement.md
+++ b/financial_agreement.md
@@ -10,7 +10,7 @@ The Foundation’s funds come from the following sources.
 
 **Venture Contributions**
 
-[Enspiral ventures](https://enspiral.gitbooks.io/enspiral-handbook/content/ventures.html) make voluntary financial contributions, usually on a monthly basis. Half a Venture’s contribution goes toward fixed costs and reserves, and half is allocated to Discretionary Funds through Cobudget. Ventures can opt for their funds to be added to their Venture’s Cobudget account, to be split equally among nominated individuals, or the venture may specify exact allocation amounts, to fund projects of their choice.
+[Enspiral ventures](ventures.html) make voluntary financial contributions, usually on a monthly basis. Half a Venture’s contribution goes toward fixed costs and reserves, and half is allocated to Discretionary Funds through Cobudget. Ventures can opt for their funds to be added to their Venture’s Cobudget account, to be split equally among nominated individuals, or the venture may specify exact allocation amounts, to fund projects of their choice.
 
 **Contributor Contributions**
 
@@ -18,7 +18,7 @@ Individuals in the network make a financial contribution to the Foundation at le
 
 **Other Income**
 
-The Foundation is a [charitable entity](https://enspiral.gitbooks.io/enspiral-handbook/content/constitution.html) not intended to bear commercial risk. However, from time to time other activities (such as serving as a fundholder for grants and projects) can result in income directly to the Foundation. Approval for such transactions is at the discretion of the Board. The Board and the people involved in bringing in the income agree how to distribute any resulting income between Normal Reserves and Discretionary Funds (via nominated users in Cobudget). These decisions and transactions are reported on the Financial Transparency page of the Handbook (as described below). 
+The Foundation is a [charitable entity](constitution.html) not intended to bear commercial risk. However, from time to time other activities (such as serving as a fundholder for grants and projects) can result in income directly to the Foundation. Approval for such transactions is at the discretion of the Board. The Board and the people involved in bringing in the income agree how to distribute any resulting income between Normal Reserves and Discretionary Funds (via nominated users in Cobudget). These decisions and transactions are reported on the Financial Transparency page of the Handbook (as described below). 
 
 ## Expenditure
 
@@ -26,13 +26,13 @@ Money flowing through or held by the Foundation falls under the following catego
 
 **Fixed Costs**
 
-Regular monthly financial commitments for expenses such as essential professional services and tools used by the network. Anyone is welcome to propose changes to fixed costs (which are reported in the Enspiral Handbook, see below). Formal approval of such requests requires a [standard decision](https://enspiral.gitbooks.io/enspiral-handbook/content/decisions_agreement.html) from Enspiral Members. 
+Regular monthly financial commitments for expenses such as essential professional services and tools used by the network. Anyone is welcome to propose changes to fixed costs (which are reported in the Enspiral Handbook, see below). Formal approval of such requests requires a [standard decision](decisions_agreement.html) from Enspiral Members. 
 
 The Board is required to regularly review fixed costs and the aim is to keep these expenses as lean as possible. The Board is permitted to adjust fixed costs by up to 10% within a 12-month period without seeking approval from the network. 
 
 **Discretionary Funds**
 
-We use a [collaborative funding](https://enspiral.gitbooks.io/enspiral-handbook/content/collabfunding.html) process through Cobudget to manage our discretionary funds. People get money to spend in the collaborative funding process through making Contributor and Venture contributions, half of which is allocated to them in Cobudget to fund projects they would like to support (the other half goes to fund Fixed Costs and Reserves). As a collective, we all share the responsibility to decide where to spend our resources, what to focus on, and what financial risks to take in pursuit of achieving our mission.
+We use a [collaborative funding](collabfunding.html) process through Cobudget to manage our discretionary funds. People get money to spend in the collaborative funding process through making Contributor and Venture contributions, half of which is allocated to them in Cobudget to fund projects they would like to support (the other half goes to fund Fixed Costs and Reserves). As a collective, we all share the responsibility to decide where to spend our resources, what to focus on, and what financial risks to take in pursuit of achieving our mission.
 
 **Emergency Fund**
 
@@ -45,7 +45,7 @@ Any funds not explicitly in Discretionary Funds, the Emergency Fund, or committe
 Anyone is welcome to propose to spend Normal Reserves for a specific purpose. Approval of such requests requires a standard decision from Enspiral Members. Normal Reserves offer an additional cushion for unexpected expenses, and enable different possibilities that come from a large number of people making collective decisions about larger amounts of money (as distinct from individuals making a series of decisions about smaller amounts of money, which is our approach for Discretionary Funds). 
 
 ## Collaborative Funding
-We make collective decisions about spending discretionary funds with a transparent and democratic processes called [collaborative funding](https://enspiral.gitbooks.io/enspiral-handbook/content/collabfunding.html) using software called Cobudget . 
+We make collective decisions about spending discretionary funds with a transparent and democratic processes called [collaborative funding](collabfunding.html) using software called Cobudget . 
 
 * All Enspiral contributors are invited to use Cobudget, and are welcome to raise bucket ideas.
 Those holding money in Cobudget decide what buckets they want to contribute funds to at their discretion.
@@ -57,7 +57,7 @@ Those holding money in Cobudget decide what buckets they want to contribute fund
 * Bucket funders are expected to use their funds responsibly, stepping beyond self-interest to make decisions on the basis of what’s best for the network as a whole.
 
 ## Reporting
-The Board is responsible for keeping up to date a [Financial Transparency](https://enspiral.gitbooks.io/enspiral-handbook/content/financial_transparency.html) section of the Enspiral Handbook, which covers:
+The Board is responsible for keeping up to date a [Financial Transparency](financial_transparency.html) section of the Enspiral Handbook, which covers:
 
 * Overview of revenue (Contributions and Income)
 * Emergency Fund (current level and any expenditures)

--- a/financial_transparency.md
+++ b/financial_transparency.md
@@ -25,8 +25,8 @@ $14,000
 |---|---|
 |  Accounting | $350  |
 |  Provisional Tax |  $240 |
-| Ops/Admin ([scope](https://enspiral.gitbooks.io/enspiral-handbook/content/ops-scope.html))  |  $3500 |
-| Comms ([scope](https://enspiral.gitbooks.io/enspiral-handbook/content/comms-role.html)) |   $400 |
+| Ops/Admin ([scope](ops-scope.html))  |  $3500 |
+| Comms ([scope](comms-role.html)) |   $400 |
 | SaaS tools  |  $1150 |
 |  **Total** | **$5240**  |
 

--- a/venture_agreement.md
+++ b/venture_agreement.md
@@ -9,10 +9,10 @@ The Enspiral network is based on high trust, reciprocity, and mutual support. Ve
 Ventures join the Enspiral network because they believe their own success is enhanced and their mission better achieved through collaborative network participation, mutual support, and interdependence. Ventures that join fundamentally value Enspiral and want to see it thrive. Many of our ventures wouldn’t exist without the support they have received from the wider network, and others choose to engage because of deep alignment of purpose and culture.
 
 **Associated Documents**
-* [Venture MOU template](https://enspiral.gitbooks.io/enspiral-handbook/content/venture_mou.html)
+* [Venture MOU template](venture_mou.html)
 * [Quarterly update form](https://docs.google.com/forms/d/11Oz-HM1Wt8CbzxZpzGmjjFcd-sp9vahoqcLuL3UysT4/viewform)
-* [Venture profile template](https://enspiral.gitbooks.io/enspiral-handbook/content/venture_profiles.html)
-* [Venture introduction template](https://enspiral.gitbooks.io/enspiral-handbook/content/venture_introduction_template.html)
+* [Venture profile template](venture_profiles.html)
+* [Venture introduction template](venture_introduction_template.html)
 
 ###Roles
 **Key Personnel**
@@ -80,7 +80,7 @@ Financial contributions by Ventures fuel the maintenance and development of Ensp
 
 Each venture defines how they wish to contribute to the network, financially and otherwise. This could be a flat monthly fee, a percentage of revenue, discounts on services, or any other contribution they wish to make. The basis of the Enspiral model is reciprocity and generosity - the expectation is to contribute at a level reasonable to the resources and stage of the venture.
 
-Financial contributions are made to the Enspiral Foundation, ideally on a monthly basis. Ventures are invited to participate in our collaborative funding process to decide how the discretionary portion of their contribution will be spent (as defined in the [Financial Agreement](https://enspiral.gitbooks.io/enspiral-handbook/content/financial_agreement.html)).
+Financial contributions are made to the Enspiral Foundation, ideally on a monthly basis. Ventures are invited to participate in our collaborative funding process to decide how the discretionary portion of their contribution will be spent (as defined in the [Financial Agreement](financial_agreement.html)).
 
 **Adjusting Contribution**
 


### PR DESCRIPTION
Makes all internal links relative. Doesn't change the behaviour, but makes the code more portable.