### PR TITLE
ii handbook pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+# define stages
+stages:
+  - build
+  - upload
+  - deploy
+
+# gitbook docker image for html & pdf
+image: billryan/gitbook
+pdf:
+  stage: build
+  tags: 
+    - handbook-docker
+  script:
+    - gitbook install
+    - gitbook pdf . ./handbook.pdf
+  artifacts:
+    name:
+      handbook
+    paths:
+      - handbook.pdf 
+
+html:
+  stage: build
+  tags: 
+    - handbook-docker
+  script:
+    - gitbook install 
+    - gitbook build
+  artifacts:
+    name:
+      html
+    paths:
+      - _book
+
+# create docker nginx image
+upload-image:
+  stage: upload
+  image: docker:latest
+  tags:
+    - handbook-docker-priv
+  services:
+    - docker:dind
+  script:
+    - echo $CI_BUILD_REF_NAME
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN docker.ii.org.nz
+    - docker build -t docker.ii.org.nz/$CI_PROJECT_NAMESPACE/handbook:$CI_BUILD_REF_NAME .
+    - docker push docker.ii.org.nz/$CI_PROJECT_NAMESPACE/handbook:$CI_BUILD_REF_NAME
+    
+# run nginx container
+publish-to-web:
+  stage: deploy
+  tags:
+    - handbook-shell
+  script:
+    - docker pull docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME
+    - docker rm -f $CI_BUILD_REF_NAME.$CI_PROJECT_NAME.$CI_PROJECT_NAMESPACE || /bin/true
+    - docker run --name $CI_BUILD_REF_NAME.$CI_PROJECT_NAME.$CI_PROJECT_NAMESPACE --env "VIRTUAL_HOST=$CI_BUILD_REF_NAME.$CI_PROJECT_NAMESPACE.$CI_PROJECT_NAME.ii.org.nz" --network handbook_default -d docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME
+    - echo Website available at http\://$CI_BUILD_REF_NAME.$CI_PROJECT_NAMESPACE.$CI_PROJECT_NAME.ii.org.nz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx
+COPY _book/ /usr/share/nginx/html
+COPY handbook.pdf /usr/share/nginx/html


### PR DESCRIPTION
# ii handbook pipeline

Inspired by Enspiral, ii wants to make it easy for groups to define who they are together.

Our pipeline creates a website per branch of each user for the handbook, so they can easily share a pdf or functioning website that includes their innovation without permission.

## Forking https://gitlab.ii.org.nz/enspiral/handbook

![image](https://cloud.githubusercontent.com/assets/31331/18331495/89204122-75b3-11e6-994a-53f335a796ec.png)

## Branching https://gitlab.ii.org.nz/ii/handbook/tree/manifesto

![image](https://cloud.githubusercontent.com/assets/31331/18331525/b7d49f9a-75b3-11e6-9d59-70c38e354dcf.png)

## Building https://gitlab.ii.org.nz/ii/handbook/pipelines/267

![image](https://cloud.githubusercontent.com/assets/31331/18331759/771f0628-75b5-11e6-9b10-ba444721c7b8.png)

## Publishing https://gitlab.ii.org.nz/ii/handbook/builds/573

![image](https://cloud.githubusercontent.com/assets/31331/18331800/c27da426-75b5-11e6-8ef9-d41b525feef9.png)

## Sharing http://manifesto.ii.handbook.ii.org.nz

![image](https://cloud.githubusercontent.com/assets/31331/18331987/09a452d6-75b7-11e6-9093-73589f97fa19.png)
