### PR TITLE
Adding space within contributing.md video tag

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ If you're making a small edit like fixing a typo, or adding a guide, the pull re
 
 Watch the quick demo video, or read on:
 
-{% video %}https://www.youtube.com/watch?v=zVvda3ci4w4{% endvideo %}
+{% video %}https://www.youtube.com/watch?v=zVvda3ci4w4 {% endvideo %}
 
 #### Step 1
 


### PR DESCRIPTION
https://gitlab.ii.org.nz/enspiral/handbook/merge_requests/2/diffs#note_98

Interesting that this produced no failures before, but does now. Possibly something about including this file in others?
https://gitlab.ii.org.nz/enspiral/handbook/builds/608

```
info: found 31 asset files 
error: error while generating page "contributing.md": 
Template render error: (/builds/enspiral/handbook/contributing.md) [Line 25, Column 57]
  tag name expected
ERROR: Build failed: exit code 1
```

After adding a space:

https://gitlab.ii.org.nz/enspiral/handbook/builds/612

```
info: found 31 asset files 
warn: "this.generator" property is deprecated, use "this.output.name" instead 
warn: "navigation" property is deprecated 
warn: "book" property is deprecated, use "this" directly instead 
warn: "options" property is deprecated, use config.get(key) instead 
info: >> generation finished with success in 12.8s ! 
Uploading artifacts...
_book: found 129 matching files                    
Uploading artifacts to coordinator... ok            id=612 responseStatus=201 Created token=R1fxbGoY
Build succeeded
```