### PR TITLE
Add dusting fairies working group page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,7 @@
   * [Conflict Resolution](guides/conflict-resolution.md)
   * [Comms Guidelines](guides/comms_guidelines.md)
   * [Contributing to the Handbook](guides/contributing.md)
+  * [Dusting fairies](guides/dusting-fairies.md)
   * [Enspiral Values](guides/values.md)
   * [Forms](guides/forms.md)
   * [Github for Beginners](guides/github_for_beginners.md)

--- a/guides.md
+++ b/guides.md
@@ -7,6 +7,7 @@ Guides explain in practical terms how we do stuff. Any Enspiral Contributor can 
 * [Conflict Resolution](guides/conflict-resolution.md) - resources for conflict resolution
 * [Comms Guidelines](guides/comms_guidelines.md) - how to know which tool to use for which kind of communication
 * [Contributing to the Handbook](guides/contributing.md) - how to edit this book
+* [Dusting fairies](working-groups/dusting-fairies.md) - how you can engage as a contributor and help content creators keep their work up-to-date
 * [Enspiral Values](guides/values.md) - some of the values that people in the network hold
 * [Forms](guides/forms.md) - some of the forms that make the network tick
 * [Github for Beginners](guides/github_for_beginners.md) - more background on editing this book

--- a/guides/dusting-fairies.md
+++ b/guides/dusting-fairies.md
@@ -1,0 +1,43 @@
+# Dusting fairies
+
+Enspiral members and contributors create a lot of content. On Github, Google Docs and more.
+
+In order to keep what we write up-to-date and consistent, « dusting fairies » came to life. These little beauties are driven by the will to make positive change, and they do so at a very granular level. They keep an eye on the actual content we create through Github (mostly the Handbook and other public facing content, but also software repositories), identify the parts that become stale or lose relevance, and suggest amendments where appropriate.
+
+Note: dusting fairies work only on Github for now, but it would be good to have some working on Google Drive documents too!
+
+## What's in with fairies?
+
+This group exists as another means to provide easily accessible tasks to contributors who are having a hard time finding how to get involved at a practical level with Enspiral.
+Doing work that has positive impact for the network should not require specific knowledge about our governance practices or processes, and should also be workable for people who have low capacity or want low engagement.
+
+Amending content and discussing with content authors are also means to directly connect to arguably the most important part of Enspiral - what gets done. By creating more direct collaboration dynamics, we envision that engagement in « working on stuff that matters » will naturally follow, and that durable cross-network connections will form between fairies and content creators.
+
+## Getting started - or how to become a fairy
+
+Follow this process with passion to witness wings growing on your back:
+
+- **Step 0 - Proclaim yourself a fairy!** - That is, make the commitment to serve the community with routine « housekeeping » work on some or any of the Enspiral Github repositories.
+ - **Step 1 - Select your first task** - Find something in any of the repositories that was authored a while ago and you think would be relevant to update. This could be some text in the handbook, an issue on the [improvement board](https://github.com/enspiral/improvements), a version of a `gem` (if you know what that is) that exposes serious security threats to one of our open-source software. Let your skills and own perception of « stuff that matters » guide you towards the piece of stale content that you want to update.
+- **Step 2 - Put yourself in the author's shoes** - Before you even notify them that some of their previous work needs a rework, think of what you would do in their place to get things sorted. Is it just a link from one of the Handbooks that needs to be removed/updated or is there a block of code along with unit-tests from the Cobudget open-source app that seem to need a rewrite? Either way, make sure you understand what needs doing, and consider whether you have the ability to fix things yourself.
+- **Step 3 - Notify the author and take steps towards resolution** - It's now time to notify the author of the issue you've found. If the content is in a file (e.g. not a Github issue), find the original commit where this content was authored [using these insructions](https://help.github.com/articles/tracing-changes-in-a-file/), and place a Github comment on the relevant line, mentioning the author and any other person you think should be notified. Your comment should ideally offer a simple solution to the issue and request mandate to amend the author's work. To make it clear to them you are contacting them in the context of your « dusting fairy » role always start your message with a :rainbow: and a link to [improvement 313](https://github.com/enspiral/improvements/issues/313), or just use the following template :
+
+```Markdown
+:rainbow: *A [dusting fairy](https://github.com/enspiral/improvements/issues/313) wants to help.
+ere is what they have to share*:
+
+---
+
+// Your message
+```
+You can use the `-  [ ] item` notation to create a checklist. This will allow you to list tasks that authors will be able give you mandate for by ticking the box (TODO - consider whether the fairy will get a notification when the tick happens?). For trivial amendments that you think are not worth disturbing the author, go straigth to committing changes.
+
+- **Step 4 - Commit changes** - Acting upon your words, and any clarification the authors gave, amend the content and commit your work. Depending on the repository, this probably means using the `git` tool to clone, create a new branch, commit, and then making a pull-request on Github. Reach out to the [`#wg-dusting-fairies` Slack channel](#wg-dusting-fairies) for any assistance with this workflow.
+
+- **Step 5 - Follow through (but don't burn your wings)** - Understand that the author may now be busy with other work, and may need to be reminded several times of the issue. However do not insist if they state that the amendment should not be made. You are a helper, and should limit the scope of your work to what is actually needed and received as help. Be extra cautious of complex tasks that would distract you from your mission. On these, limit *step 3* to a simple notification, not the actual implementation of a solution.
+
+You can find an example of a dusting fairy at work [here](https://github.com/enspiral/handbook/commit/bde6f77889172219c3d8741f494c97d1701fc77f#commitcomment-22974043).
+
+## Discuss
+
+The emergence of this group is discussed in [this Loomio](https://www.loomio.org/d/P97tAUYQ). Conversation is also happening in the [#activation-program](https://enspiral.slack.com/messages/C56MTV8SV/convo/C56MTV8SV-1499108780.752336/) Slack channel. Feel free to join and weight in your thoughts!


### PR DESCRIPTION
This creates a handbook page for the « dusting fairies » working group.

[Link to the Loomio](https://www.loomio.org/d/P97tAUYQ)
[Link to the improvement ticket](https://waffle.io/enspiral/improvements/cards/595f9608c5373702d6c27bca)