### PR TITLE
Remove broken/stale links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ The book is broken up into chapters and sub-chapters. The chapters are:
 The information in this handbook pertains to Enspiral Foundation Limited and the Enspiral network as a whole. Many Enspiral ventures and teams will have different processes, which live in their own handbooks e.g.:
 
 * [The Loomio Cooperative Handbook](http://loomio.coop)
-* [The Enspiral Labs Handbook](http://labs-handbook.enspiral.com)
-* [The Enspiral Dev Academy Handbook](http://handbook.devacademy.co.nz/)
 
 There's an increasing number of companies outside of Enspiral that are also documented with public handbooks:
 


### PR DESCRIPTION
This removes two links to external handbooks. I'd rather see this not merged and the links fixed if possible. As per [comment here](https://github.com/enspiral/handbook/commit/bde6f77889172219c3d8741f494c97d1701fc77f#commitcomment-22974043):

- http://handbook.devacademy.co.nz Leads to a Cloudflare 1001 error. 
- http://labs-handbook.enspiral.com is fairly incomplete and not maintained anymore. Probably not the best example for the readme.

I pingged JV about it and will give this a week before a merge.