### PR TITLE
Update book.json to add Google Analytics

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,12 @@
   "styles": {
     "website": "styles/website.css"
   },
-  "plugins": [ "collapsible-menu", "video" ],
+  "plugins": [ "collapsible-menu", "video", "ga" ],
+  "pluginsConfig": {
+        "ga": {
+            "token": "UA-1616271-11"
+        }
+  },
   "variables": {
     "org": "Enspiral"
   }


### PR DESCRIPTION
Add the Google Analytics plugin to the Enspiral Handbook.  

My understanding is that gitbook will automatically install the ga (Google Analytics) plugin when the repo is synced back to gitbook.com