### PR TITLE
Add members link

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -14,6 +14,7 @@ Guides explain in practical terms how we do stuff. Any Enspiral Contributor can 
 * [Google apps](guides/google_apps.md) - how to get an Enspiral email account
 * [Improvements](guides/improvements.md) - how to make changes to the network
 * [Onboarding Emails](guides/onboarding-info.md) - messages sent to new contributors
+* [Ops processes](guides/ops_processes.md) - a list of some of ops processes
 * [People\*](guides/people.md)
 * [Project Kitchens](guides/project_kitchen.md) - an energising process for efficiently giving mutual support to projects through enabling group intelligence
 * [Projects & Reports](guides/projects_reports.md)

--- a/guides/people.md
+++ b/guides/people.md
@@ -1,3 +1,5 @@
 # People
 
-To be done
+Enspiral members on the [web](https://enspiral.com/about-enspiral/people/)
+
+Page still to be completed.


### PR DESCRIPTION
Adding a link to the members page on the web. This is the MVP for getting a members list  in the handbook.