### PR TITLE
Ops update onboarding

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -14,6 +14,7 @@ Guides explain in practical terms how we do stuff. Any Enspiral Contributor can 
 * [Google apps](guides/google_apps.md) - how to get an Enspiral email account
 * [Improvements](guides/improvements.md) - how to make changes to the network
 * [Onboarding Emails](guides/onboarding-info.md) - messages sent to new contributors
+* [Ops processes](guides/ops_processes.md) - a list of some of ops processes
 * [People\*](guides/people.md)
 * [Project Kitchens](guides/project_kitchen.md) - an energising process for efficiently giving mutual support to projects through enabling group intelligence
 * [Projects & Reports](guides/projects_reports.md)

--- a/guides/ops_processes.md
+++ b/guides/ops_processes.md
@@ -1,6 +1,6 @@
 #Ops processes
 
-This is a list of processes that Ops runs in Enspiral Foundation and which are part of our [scope of work](ops-scope.md). We'll build this up over time.
+This is a list of processes that Ops runs in Enspiral Foundation and which are part of our [scope of work](https://handbook.enspiral.com/ops-scope.html). We'll build this up over time.
 
 - Contributor onboarding, annual opt-ins, offboarding and maintenance
 - Bookkeeping, maintaining collab finance
@@ -13,16 +13,39 @@ This is a list of processes that Ops runs in Enspiral Foundation and which are p
 
 ###Onboarding
 
+Enspiral Members complete the “Add new contributor form” listed on the [Forms page](https://handbook.enspiral.com/guides/forms.html) in the handbook. Members are the new Contributor’s Steward by default unless they have arranged for someone else to be their Steward. 
+
+Upon completion of this Form, Ops receives a notification with all of the details. At the same time, the new Contributor is sent an automated email with a link and request to complete the Contributor Details Form. Ops waits for the new Contributor to complete this form before onboarding them to the Enspiral apps and systems. 
+
+The new Contributor completes this form, supplying the following info: Facebook login email, personal tagline/origin story, website, ask me about…, skills, activities, values, interests, bio/introduction, aspirations within the network. Ops receives a notification when the form is completed and that the Contributor is ready to be onboarded to the network.
+
+Ops onboards the new Contributor by inviting them to join to the following systems:
+
+- Enspiral Loomio
+- Enspiral Slack
+- Secret Enspiral Facebook Group
+- Cobudget
+- Added to the Foundation Google Apps Contributors Group
+- Added to receive the [Onboarding Email Series](https://handbook.enspiral.com/guides/onboarding-info.html)
+
+If the new Contributor is getting an Enspiral Google Apps account, all of the above invites are generally sent to the new Google Apps account address unless the contributor prefers for these to be sent to their personal address.
+
+At this point the Contributor is considered “Onboarded” with a “Trial” status. The onboard date is created and a new Opt-in Request date is set for 3 months (90 days) after the onboard date. The [Contributors & Members Directory](https://docs.google.com/a/enspiral.com/spreadsheets/d/1-ZdYOEZ9KXpd8W166Pt-uTQdrsoXcmgZkURU3955L-w/edit?usp=drive_web) is updated with the new Contributors details.
+
+Once the new Contributor has logged into the Loomio Enspiral Group for the first time, Ops receives a notification. Ops introduces the new Contributor in the [New contributor welcome and introductions Discussion in Loomio](https://www.loomio.org/d/n1Uie3LW/new-contributor-welcome-and-introductions), tagging their inviting Member and Steward, and records the welcome date in the back end database. Ops then invites the new Contributor to join the “[Enspiral Opportunities // Ask Enspiral](https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral)” Enspiral Loomio sub-group.
+
+The new Contributor is now fully onboarded to all of Enspiral’s systems.
+
 ###Annual opt-in
 
 After 3 months in the network, and once a year after that, we ask Contributors to proactively decide if they'd like to stay on in the network. (Enspiral members are also contributors, and they go through this same process).
 
-- Near the "Subscription Date" dictated by the above 3-month or annual Enspiral birthdate, Contributors are sent an email with a custom-link to the Opt-in form. This is sent via our operationshelpdesk Gmail account, with the name "Charley at Enspiral Foundation". The email is sent to both a "Personal email address" and secondary "Enspiral email address" from our database of Contributors. We recently modified this to also send a Slack notification to the contributor about their request to "Opt-in". At this point, an email is also sent to the Contributor's Steward, if they have one, suggesting that this is a good time to check in with them, since this is a specific period of time that they'll be considering to Opt-in or out of the network. (Stewards have the option of not receiving this notification.)
+- Near the "Subscription Date" dictated by the above 3-month or annual Enspiral birthdate, Contributors are sent an email with a custom-link to the Opt-in form. This is sent via Mandrill, with the name "Charley at Enspiral Foundation". The email is sent to both the "preferred email address" from our database of Contributors. We recently modified this to also send a Slack notification to the contributor about their request to "Opt-in". At this point, an email is also sent to the Contributor's Steward, if they have one, suggesting that this is a good time to check in with them, since this is a specific period of time that they'll be considering to Opt-in or out of the network. (Stewards have the option of not receiving this notification.)
 
-- One week after sending the "Opt-in" email, if Ops does not receive a response from the contributor, a "Final Reminder" email is sent to the contributor at both their personal and enspiral email addresses (if they have one), with their custom opt-in google form link, and a caution that if we do not receive a response within one further week, we'll take it to mean that they're Opting-out by default. We also send a reminder via Enspiral Slack (recently added notification.)
+- Two weeks after sending the "Opt-in" email, if Ops does not receive a response from the contributor, a "Final Reminder" email is sent to the contributor at both their personal and enspiral email addresses (if they have one), with their custom opt-in google form link, and a caution that if we do not receive a response within one further week, we'll take it to mean that they're Opting-out by default. We also send a reminder via Enspiral Slack (recently added notification.)
 
-- Two weeks after sending the "Opt-in" email, if Ops still does not receive a response, we send a "Farewell" email to the Contributor (at both email addresses), saying that we will be removing them from Enspiral systems within one week, unless there's been some mistake. At this point, we also send a follow-up email notification to the Contributor's Steward, advising that unless they think there's been some mistake or problem with the contributor opting-in, Ops will opt-out the contributor by default and remove them from Enspiral systems.
+- Four weeks after sending the "Opt-in" email, if Ops still does not receive a response, we send a "Farewell" email to the Contributor (at both email addresses), saying that we will be removing them from Enspiral systems within one week, unless there's been some mistake. At this point, we also send a follow-up email notification to the Contributor's Steward, advising that unless they think there's been some mistake or problem with the contributor opting-in, Ops will opt-out the contributor by default and remove them from Enspiral systems.
 
-- Three weeks after sending the "Opt-in" email, if Ops has not received any notification from the Contributor or Steward, we presume the Contributor does not wish to stay in the network and we process the Contributor to be removed from the Enspiral Systems
+- Five weeks after sending the "Opt-in" email, if Ops has not received any notification from the Contributor or Steward, we presume the Contributor does not wish to stay in the network and we process the Contributor to be removed from the Enspiral Systems
 
 ###Offboarding


### PR DESCRIPTION
- I added info on the Onboarding process
- In the Annual Opt-in section, I updated the timeframes for which emails are sent to contributors
- I fixed a broken link to the ops processes page - unsure why this wasn't loading previously.