### PR TITLE
Ops updates

### DIFF
--- a/board.md
+++ b/board.md
@@ -32,27 +32,23 @@ Examples of things within scope:
 
 ## Current Directors
 
+### Ants Cabraal
+Ants has worked across several ventures in roles like investor, director, co-founder, business development, marketing & creative production. Currently focused on building Enspiral ventures working in education and professional development. He stays up late scheming about creative projects to help make the world a more peaceful place.
+
+### Bart de Vries
+Bart is intent on moving the world. He has an eclectic background. Working as a Physiotherapist with high performance/professional athletes as well as helping Joe blog with with an injury or persistent pain get back to living, life and work. He has also spent a lot of his life playing sport himself, travelling the world playing golf, playing hockey here for Capital and heading to the Netherlands for 2 seasons to experience a professionals lifestyle (as well as becoming a coffee roaster). Bart then came back to Wellington a year ago and started a market stall making Dutch Stroopwafels (strOpee). This was a project to see if you can develop meaning out of something seemingly meaningless and learn about business. While launching strOpee Bart was also fully involved in creating a new Physiotherapy space and service in Palmerston North.
+
+Now Bart is back in Wellington and intent on moving the world, getting people focused on their health, wellbeing, their vitality and happiness. He no longer wants to be at the bottom of the cliff but rather is getting to the top, fencing it off and sign posting to make an impact on how this world functions and where to moves to next.
+
 ### Billy Matheson
 I am a social entrepreneur who brings a unique set of skills and perspectives to every project I get involved with. My educational background is in Industrial Design (B.Des Victoria) and Adult Education (M.Ed, Massey). In 2009 I was involved in founding the ReGeneration youth leadership project in partnership with Enviroschools and the Tindall Foundation, where I met many Enspiral people. In 2012 I was employed by Auckland Council as their Principal Advisor on Social Entrepreneurship, a role that I was in for three years. I am involved with three Enspiral Ventures and serve in a governance capacity with a number of other companies and trusts.
 
 I really like working with complexity, and for that reason I want the things that can be simple and clear to be as simple and clear as possible - like the MVB. The key thing to understand about the MVB concept is that, if it works, it will free the directors to focus on governance rather than operational issues. With the Catalysts in action, Venture Stewards doing their thing, and the Enspiral Handbook underway, the MVB can get on with fundamental compliance issues like processes for appointing new directors, financial reporting, and managing risk. It also means that, like directors of any other Enspiral venture, we can spend more time thinking about how Enspiral Foundation Ltd can be more awesome. This is a massive improvement on what we had before, so definitely watch this space!
 
-### Silvia Zuur
-I grew up in a sailing boat on the Kapiti Coast. After a Steiner and then Victoria University education, I managed Commonsense organics in Wellington (my first and only "proper" job), before taking off to Benin in West Africa. It took me three years to come home, as I ended up working for an international youth organisation in Switzerland.
-
-I've now spent the last five years within the Enspiral network. I grew my entrepreneurship muscles growing Chalkle, and some event management muscles organising the Social Enterprise Conference and UX Design Day. Now I'm developing those further in supporting Chalkle into its next phase and building EXP, where I'm building OS//OS into a 10 year vision with an awesome team!
-
-In terms of governance, I love thinking about form to enable freedom. I like keeping a tidy house, ensuring that the lights will stay on so awesome humans can do awesome work. For me, It's all about the humans first. So when it comes to my role I do think a lot about the systems and processes, but at the end of the day it's about people.
-
-*He aha te mea nui o te ao*
-
-*He tangata, he tangata, he tangata*
-
-*What is the most important thing in the world?*
-
-*It is the people, it is the people, it is the people*
-
 ### Rob Guthrie
 Lifelong programmer with a passion for the power of the internet to transform society and improve lives. Serial entrepreneur, business and product strategist, and relentless problem solver. Loves building useful tools that real people use. Supports others to learn and grow.
+
+### Susan Basterfield
+I’m a catalyst, cultivator, convenor and curator, helping individuals and organisations experiment with new ways of working and being. I’m a member of the Golden Pandas livelihood pod, serve as an Enspiral Foundation Catalyst, engage in acts of ambassador-ing, and work with teams worldwide as a coach and facilitator. I convene Teal NZ, with over 350 members. And I like to write.
 
 {% include 'contributing_hint.md' %}

--- a/collabfunding.md
+++ b/collabfunding.md
@@ -10,12 +10,7 @@ In your invoice, be sure to include:
 * the total amount for the bucket (remember, the amounts in Cobudget are GST-exclusive)
 * bucket name and URL
 * a clear indication of whether GST is included in your invoice
-* bank account numbe
-* the total amount for the bucket
-* a clear indication whether GST is included in your invoice (remember the Cobudget amounts are GST-exclusive)
-* your name, contact email and bank account number
-* whether you are invoicing for you personally or on behalf of an Enspiral venture
-* the web address and name of the Cobudget bucket.
+* bank account number
 
 Here's a link to the [Financial Agreement](/agreements/financial.html)
 

--- a/collabfunding.md
+++ b/collabfunding.md
@@ -1,12 +1,16 @@
 # Collaborative Funding
 
+The Greaterthan team are working with Enspiral and the Ops Team to deliver Facilitated Cobudget rounds on a monthly basis. (Contributors only: read more context about this on Loomio: [https://www.loomio.org/d/DbW3nipl/it-s-time-facilitated-cobudget-](https://www.loomio.org/d/DbW3nipl/it-s-time-facilitated-cobudget-)
+
 ## How to get paid for a Cobudget Bucket
 
-First, you need to figure out whether you're invoicing Enspiral Services or Enspiral Foundation. See the [Venture Profiles](/venture_profiles.html) if you're not sure.
+Once you've proposed a Bucket and it gets Funded (Woohoo! High-five!!), at the end of the funding round you will be contacted by email with a request to send an invoice to Enspiral Foundation via foundation@enspiral.com.
 
-Then, if your work was for Foundation, fill out [this form first](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSdr9pugQocyDm28R0he71za00bfLQ80Azgff9flSzKjpjFwog/viewform)
-
-If your work was for an Enspiral Services bucket, email services@enspiral.com with an invoice that includes:
+In your invoice, be sure to include:
+* the total amount for the bucket (remember, the amounts in Cobudget are GST-exclusive)
+* bucket name and URL
+* a clear indication of whether GST is included in your invoice
+* bank account numbe
 * the total amount for the bucket
 * a clear indication whether GST is included in your invoice (remember the Cobudget amounts are GST-exclusive)
 * your name, contact email and bank account number
@@ -14,13 +18,5 @@ If your work was for an Enspiral Services bucket, email services@enspiral.com wi
 * the web address and name of the Cobudget bucket.
 
 Here's a link to the [Financial Agreement](/agreements/financial.html)
-
-## Coming soon!
-
-History of Collborative Funding at Enspiral
-
-How Enspiral uses Cobudget
-
-Link to previous collab funding annual reports
 
 {% include 'contributing_hint.md' %}

--- a/financial_transparency.md
+++ b/financial_transparency.md
@@ -1,6 +1,6 @@
 # Financial Transparency
 
-**Note: This page is accurate as of October 2016 **
+**Note: This page is accurate as of October 2017 **
 
 How money works at Enspiral is determined by the [Financial Agreement](/agreements/financial.html). This page is to provide information and transparency about our financial situation.
 ## Income and Expenses
@@ -12,24 +12,20 @@ __Venture__ contributions:
 
 | $ | From |
 |---|---|
-| 1.5k - 2.5k | Services |
-| 700 | Lifehack |
 | 500 | EDA |
-| 400 - 650 | Accounting |
+| 400 - 650 | Fairground |
 | 200 | Loomio |
-| 200  | Rabid |
-| 100 | Ops |
 | 40  | ActionStation |
 
-__Contributors__ pay an annual fee averaging at about $100 per person. Half of this is allocated by contributors using Cobudget - I've listed this as an expense below.
+__Contributors__ pay an annual fee of $100 per person.
 
 So Foundation __monthly income__ is:
 
 | $ | source |
 |---|---|
-| 2090 | ventures |
-| 1833 | contributors |
-| 3923 | __total__ |
+| 1140 | ventures |
+| 1416 | contributors |
+| 2556 | __total__ |
 
 ### Expenses
 
@@ -45,20 +41,26 @@ So Foundation __monthly income__ is:
 | 5846 | __total__ |
 
 ## Money we have
+*(Contributors only: check out the [Enspiral Foundation Financials Loomio Discussion](https://www.loomio.org/d/DIejiytR/enspiral-foundation-ltd-financials) for the latest discussion and information.
+
+### Invoices & Expenses
+*Normal cashflow account where bills are paid and sales invoice income first enter Foundation's bank account
+
+$10,270
 
 ### Emergency Fund
 *Amount set aside by the Board of Directors*
 
-$10,000
+$10,068
 
 ### Normal Reserves
 *Spending these funds is a decision of the Enspiral Members*
 
-$28,537.18 in reserves
+$21,519 in reserves
 
 ### Foundation Cobudget
 This is money that has been allocated in the foundation cobudget system but has not been spent. We're considering what we want to do about all this money as it is continuing to increase.
 
-$34,000 in Foundation Cobudget
+$22,562 in Foundation Cobudget
 
 {% include 'contributing_hint.md' %}

--- a/financial_transparency.md
+++ b/financial_transparency.md
@@ -34,11 +34,10 @@ So Foundation __monthly income__ is:
 | $ | thing |
 |---|---|
 | 3200 | Enspiral Ops ([scope](ops-scope.html))|
-| 916 | Cobudget |
-| 900 | Google |
+| 140 | General Expenses (bank fees, company registration, accounting etc.) |
+| 322 | SaaS|
 | 480 | Comms ([scope](comms-role.html)) |
-| 350 | ACC |
-| 5846 | __total__ |
+| 4142 | __total__ |
 
 ## Money we have
 *(Contributors only: check out the [Enspiral Foundation Financials Loomio Discussion](https://www.loomio.org/d/DIejiytR/enspiral-foundation-ltd-financials) for the latest discussion and information.

--- a/guides/comms_guidelines.md
+++ b/guides/comms_guidelines.md
@@ -22,6 +22,21 @@ The issues list and the waffle board are different views to the same information
 
 Daily chatting, realtime comms, quick questions, interesting links. There is a #watercooler channel for general discussion, and many channels for teams, projects, locations, and topics, or you can create your own! 
 
+Here's a list of popular Slack Channels:
+* Cobudget - Find help: [https://cobudget.slack.com](https://cobudget.slack.com) OR support@cobudget.co, Plan:  [https://trello.com/b/Ca4BpYOz/cobudget-sprint-board](https://trello.com/b/Ca4BpYOz/cobudget-sprint-board)
+* Cool-Shit
+* Dev-Chat - For talk about programming stuff
+* Enspiral_Help - How do I enspiral?
+* Enspiral-News - A channel to add in any links or news you would like to have shared in the next issue of Enspiral news. If there is important or useful context you would like included, please drop that in as well
+* Enstagram - Like Enspiral-Instragam: a place we can share snapshots from daily life so it feels like we are hanging out together even when we’re all over the world!
+* Music
+* Network map - Network Map Here: [https://kumu.io/enspiral/enspiral](https://kumu.io/enspiral/enspiral) [Documentation here](https://docs.google.com/document/d/1p7pQDsr1KbEaOE5Zv5i1NsVpazPBLe8iLjYCRcBRIE4/edit#heading=h.b2negpxbz2ky)
+* Stewardingv2 - [https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-](https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-)
+* Thanks
+* Want-Ads - enspiral classifieds + mirror of Enspiral Opportunities = [https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral](https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral)
+* Watercooler
+* Wellington
+
 **[Cobudget](beta.cobudget.co/#/groups/41) - Collaborative Funding**
 
 Our tool for budgeting and financial decision making. Enspiral's discretionary budget is distributed using a democratic process. All contributors are welcome to raise buckets (funding requests) and comment on buckets. If your message is about spending collective money, it probably makes sense to post it here as a bucket or comment.
@@ -73,21 +88,6 @@ Know the various channels available and consciously decide where to post. Within
 * Long form public sharing goes on Enspiral Tales
 
 Messages relevant only to a limited group of people should be emailed directly, or posted in a specific Slack channel or Loomio subgroup.
-
-Here's a list of popular Slack Channels:
-* Cobudget - Find help: [https://cobudget.slack.com](https://cobudget.slack.com) OR support@cobudget.co, Plan:  [https://trello.com/b/Ca4BpYOz/cobudget-sprint-board](https://trello.com/b/Ca4BpYOz/cobudget-sprint-board)
-* Cool-Shit
-* Dev-Chat - For talk about programming stuff
-* Enspiral_Help - How do I enspiral?
-* Enspiral-News - A channel to add in any links or news you would like to have shared in the next issue of Enspiral news. If there is important or useful context you would like included, please drop that in as well
-* Enstagram - Like Enspiral-Instragam: a place we can share snapshots from daily life so it feels like we are hanging out together even when we’re all over the world!
-* Music
-* Network map - Network Map Here: [https://kumu.io/enspiral/enspiral](https://kumu.io/enspiral/enspiral) [Documentation here](https://docs.google.com/document/d/1p7pQDsr1KbEaOE5Zv5i1NsVpazPBLe8iLjYCRcBRIE4/edit#heading=h.b2negpxbz2ky)
-* Stewardingv2 - [https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-](https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-)
-* Thanks
-* Want-Ads - enspiral classifieds + mirror of Enspiral Opportunities = [https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral](https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral)
-* Watercooler
-* Wellington
 
 **Subject Lines**
 

--- a/guides/comms_guidelines.md
+++ b/guides/comms_guidelines.md
@@ -4,7 +4,7 @@ This guide is here to give an overview of the channels we've decided to adopt an
 
 These comms channels are hosted by the Enspiral Foundation and are open to all contributors (or wider). If you are a contributor but lack access to something, contact foundation@enspiral.com
 
-# Channels and Tools
+# Comms Platforms and Tools
 
 **[Loomio](https://www.loomio.org/g/1xCPyY46/enspiral) - Group Decisions**
 
@@ -22,10 +22,6 @@ The issues list and the waffle board are different views to the same information
 
 Daily chatting, realtime comms, quick questions, interesting links. There is a #watercooler channel for general discussion, and many channels for teams, projects, locations, and topics, or you can create your own! 
 
-**[Chalkle](http://www.chalkle.com/enspiral) - Events/Classes**
-
-Enspiral's Chalkle Channel is where events and classes are posted that everyone is welcome to attend. If you'd like to host one, feel free! They can be free or you can charge. Chalkle events are visible on the public internet, but only 'followers' of the channel (including all contributors) will get a direct invitation. [More info](https://docs.google.com/document/d/1Phe94mRRo5yMpxiNiZiiX-sRKpsDQcDTbh9J7sdjIBY/edit?usp=sharing).
-
 **[Cobudget](beta.cobudget.co/#/groups/41) - Collaborative Funding**
 
 Our tool for budgeting and financial decision making. Enspiral's discretionary budget is distributed using a democratic process. All contributors are welcome to raise buckets (funding requests) and comment on buckets. If your message is about spending collective money, it probably makes sense to post it here as a bucket or comment.
@@ -38,9 +34,9 @@ To get something published in News, email news@enspiral.com or post in the #ensp
 
 **Google Apps**
 
-* Email - Everyone at Enspiral is entitled to an Enspiral email address if they need one to represent Enspiral to clients or the public. Email is great for one-on-one or small group correspondence, or one-way announcements. There are more details on the [Google Apps page](google_apps.md).
+* Email - Everyone at Enspiral can pay a subscription fee to have an Enspiral email address if they need one to represent Enspiral to clients or the public. Email is great for one-on-one or small group correspondence, or one-way announcements. There are more details on the [Google Apps page](google_apps.md).
 
-* Calendar - Great for your own planning and for private events and meetings where you have a specific guest list in mind. If you want to put out an open invitation, use [Chalkle](http://www.chalkle.com/enspiral) instead.
+* Calendar - Great for your own planning and for private events and meetings where you have a specific guest list in mind. 
 
 * Drive - We use Drive (Docs, Sheets, Forms) extensively, but we're moving all 'official' documentation off it and onto GitHub. If a team you're working with uses Drive, you'll be invited to the relevant folders/docs.
 
@@ -70,7 +66,6 @@ Know the various channels available and consciously decide where to post. Within
 
 * Topics requiring a group decision and affecting everyone go on Loomio
 * Issues, improvements and general discussion go on Github or Waffle
-* Events go on Chalkle
 * Broadcast announcements to all contributors go in News
 * Casual realtime communication goes on Slack. You will reach whoever opts in to read when you happen to post.
 * Other casual communication goes in the Facebook group - again you'll reach whoever opts in there.
@@ -78,6 +73,21 @@ Know the various channels available and consciously decide where to post. Within
 * Long form public sharing goes on Enspiral Tales
 
 Messages relevant only to a limited group of people should be emailed directly, or posted in a specific Slack channel or Loomio subgroup.
+
+Here's a list of popular Slack Channels:
+* Cobudget - Find help: [https://cobudget.slack.com](https://cobudget.slack.com) OR support@cobudget.co, Plan:  [https://trello.com/b/Ca4BpYOz/cobudget-sprint-board](https://trello.com/b/Ca4BpYOz/cobudget-sprint-board)
+* Cool-Shit
+* Dev-Chat - For talk about programming stuff
+* Enspiral_Help - How do I enspiral?
+* Enspiral-News - A channel to add in any links or news you would like to have shared in the next issue of Enspiral news. If there is important or useful context you would like included, please drop that in as well
+* Enstagram - Like Enspiral-Instragam: a place we can share snapshots from daily life so it feels like we are hanging out together even when we’re all over the world!
+* Music
+* Network map - Network Map Here: [https://kumu.io/enspiral/enspiral](https://kumu.io/enspiral/enspiral) [Documentation here](https://docs.google.com/document/d/1p7pQDsr1KbEaOE5Zv5i1NsVpazPBLe8iLjYCRcBRIE4/edit#heading=h.b2negpxbz2ky)
+* Stewardingv2 - [https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-](https://www.loomio.org/d/JjhvAxdc/stewardship-update-2017-)
+* Thanks
+* Want-Ads - enspiral classifieds + mirror of Enspiral Opportunities = [https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral](https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral)
+* Watercooler
+* Wellington
 
 **Subject Lines**
 

--- a/guides/forms.md
+++ b/guides/forms.md
@@ -6,7 +6,6 @@ These are some of the forms that help make Enspiral tick. They're all connected 
 ### All contributors
 
 * Update your details in the [Enspiral Members & Contributor database](https://docs.google.com/spreadsheets/d/1-ZdYOEZ9KXpd8W166Pt-uTQdrsoXcmgZkURU3955L-w/edit#gid=206903456) via this [Contributor Details form](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSeExKCL4UhU3LdRzF0aSkn-nhw7b-Hdyl0PCfgO9KkAeqwulg/viewform)
-* Get your Cobudget bucket paid out [bucket payout form](https://handbook.enspiral.com/collabfunding.html)
 * [Annual contributor opt-in form](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSfbcTxIiZR4zvZlVOugVkXb34bcg4iUeB5uwDXveVODOGr5jg/viewform?entry.190767353&entry.977126547=100&entry.1019976978&entry.2103714586&entry.39252034)
 * Add or remove your [Google Apps email account](google_apps.md)
 * Go to the [Variable contributions form](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSdSilcJMsP5UCNUwr4e-sElSf0QYt6bLr0zr1g9Sc2-86WHOQ/viewform) to request a  one off contribution.
@@ -18,7 +17,6 @@ These are some of the forms that help make Enspiral tick. They're all connected 
 * To add a new member, leave membership or change your hiatus status, go to the [Member status change form](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSe3pO-XEzduRM3UgrnW1GqAFm9F8NQaHHanjizgpn9EoWyBQA/viewform)
 
 ###Ventures
-
 
 * To add a new venture or proto-venture to the network, go to the [New Enspiral venture form](https://docs.google.com/a/enspiral.com/forms/d/1KpnihByGGSiio0_-ipwG8NML_kXHDe5-Tiq8GrqWq1I/edit?usp=drive_web)
 

--- a/guides/onboarding-info.md
+++ b/guides/onboarding-info.md
@@ -23,10 +23,13 @@ Week 6 : Tell us how you’re going
 
 At any time you can access any of these messages on the [Onboarding page in our Enspiral Handbook].
 
-Our communications tools.
+**Our communications tools.**
+
 At Enspiral we use a number of online platforms to meet our organisational needs. As a new contributor, you should have received an invite to all of these. If any of these hasn’t turned up feel free to send us a message at foundation@enspiral.com.
 
-Core channels for everyone :
+The [Comms Guide](https://handbook.enspiral.com/guides/comms_guidelines.html) in the Enspiral Handbook is your go to place if you're confused about which platform is best to share your idea or how to connect with other contributors.
+
+**Core comms platforms for everyone:**
 
 Enspiral News - our fortnightly newsletter with important info and announcements.
 
@@ -34,22 +37,22 @@ Enspiral News - our fortnightly newsletter with important info and announcements
 
 [Cobudget](http://cobudget.co/#/) - this is how we decide how to spend our surplus each month. Anyone in the network can propose ideas for funding and people who have contributed financially to the network allocate their money here.
 
-[Chalkle](https://chalkle.com/enspiral) - this is where official Enspiral events are listed. Everyone in the network is able to post events here you’d like to host.
-Optional channels :
-Feel free to pick and choose from these different places Enspiralites hang out online.
+Contributor & Member Directory - this is a Google Drive database where you can find a list of all the other active Contributors and Members. Included are Contributor details such as bios, location, interests, skills and more. (*Note: a link to the Directory is included in the actual email series.)*
+
+**Optional comms platforms:**
+
+**Feel free to pick and choose from these different places Enspiralites hang out online.**
 
 [Slack](https://enspiral.slack.com/messages) - team messaging app where informal conversations are held. Remember to fill out [your profile](https://get.slack.help/hc/en-us/articles/204092246-Editing-your-profile) as soon as you can!
 
 [Facebook group](https://www.facebook.com/groups/enspiral/) - informal discussions and inspiration-sharing.
 
-[Hylo group](https://www.hylo.com/c/enspiral) - collaboration and resource-sharing. [Click here](https://www.hylo.com/signup?next=%2Fc%2Fenspiral%2Fjoin%2Funguessablepassword&id=enspiral&action=join-community) to join.
-
 [GitHub](https://github.com/enspiral) - documentation and code development.
 
-We know this is quite a lot to take in. We suggest you start with Loomio and your choice of optional channels and go from there. You can also check out our [Comms Guide](/comms_guidelines.html) for more information.
+We know this is quite a lot to take in. We suggest you start with Loomio and your choice of optional channels and go from there. And a friendly reminder, you can also check out our [Comms Guide](/comms_guidelines.html) for more information.
 
 
-Happy Enspiraling!
+Happy Enspiralling!
 
 
 Enspiral Foundation
@@ -58,118 +61,115 @@ Enspiral Foundation
 
 Kia ora,
 
-Above all else, Enspiral is a community and it’s our relationships with each other that make everything work. To help welcome you on your social journey into the network, you have been assigned a Steward. Your Steward looks after your relationship with the Enspiral network as a whole, and is your one guaranteed point of contact.
+Above all else, Enspiral is a community and it’s our relationships with each other that make everything work. To help welcome you on your social journey into the network, you have been matched with a Steward. **Your Steward looks after your relationship with the Enspiral network as a whole, and is your one guaranteed point of contact.**
 
-In most cases, your Steward will be the Enspiral member who invited you to the network, but not always.
+**Next steps:**
 
-Next steps:
+The Ops team will send you an email in the next few days confirming the name of your steward, and prompting you to connect with them. After receiving this, contact your steward to arrange either a meet-up or video call. This will help you both to get to know each other. Your Steward will ask you questions to understand your intentions and aspirations coming into Enspiral, and introduce you to other people in the network who might share similar dreams.
 
-The Enspiral Operations team will send you an email in the next few days confirming the name of your steward, and prompting you to connect with them. After receiving this, contact your steward to arrange either a meet-up or video call. This will help you both to get to know each other. Your Steward will ask you questions to understand your intentions and aspirations coming into Enspiral, and introduce you to other people in the network who might share similar dreams.
-
-As a new Contributor, your job is to find the people within our network that most resonate with what you want to create in the world. Your Steward is here to help.
+As a new Contributor, your job is to find the people within our network who most resonate with what you want to create in the world. Your Steward is here to help.
 
 Happy connecting!
 
 ## Week 3 email: So what does it mean to be an Enspiral Contributor?
 Kia ora,
 
-So what does it mean to be an Enspiral Contributor?
+**So what does it mean to be an Enspiral Contributor?**
 
 Enspiral Contributors are the life of Enspiral. But what are you contributing to and how do you do it? Below is an extended version of our [People Agreement](/agreements/people.html) which sets out what is required, expected and encouraged from Contributors in being valuable citizens of Enspiral.
 
-Required :
+**Required:**
 
-  * Accept the invitation to the Enspiral Loomio group
+  * **Accept** the invitation to the Enspiral Loomio group
 
-  * Follow agreed Enspiral policies (such as the [Diversity Agreement](/agreements/diversity.html))
+  * **Follow** agreed Enspiral policies (such as the [Diversity Agreement](/agreements/diversity.html) and the [Personal Conduct Agreement](personal_conduct.html))
 
-  * Opt in after 3 months and every 12 months after that, and make a self-set financial contribution (see [Financial Agreement](/agreements/financial.html))
+  * **Opt in** after 3 months and every 12 months after that, and make a self-set financial contribution (see [Financial Agreement](/agreements/financial.html))
 
-Expected :
+**Expected:**
 
-  * Participate in online communications channels and collective decisions on Loomio.
+  * **Contribute** to the internal culture of support and generosity.
+  
+  * **Participate** in online communications channels and collective decisions on Loomio.
 
-  * Allocate funds in [Cobudget](http://cobudget.co/#/groups/41) when you have them.
+  * **Allocate funds** in [Cobudget](http://cobudget.co/#/groups/41) when you have them.
 
-  * Contribute to the internal culture of support and generosity.
+  * **Help build** Enspiral in your own way - no one here will tell you what to do.
 
-  * Help build Enspiral in your own way - no one here will tell you what to do.
+  * If you **notice** something that can be improved, work on it or talk to people about it. Read the [Improvements Guide](/guides/improvements.html) and add your idea to the Improvements Board, or [posting a bucket idea in Cobudget](http://cobudget.co/#/buckets/new?group_id=41) are great places to start.
 
-  * If you notice something that can be improved, work on it or talk to people about it. Starting a [seed on Hylo](https://www.hylo.com/c/enspiral) or [posting a bucket idea in Cobudget](http://cobudget.co/#/buckets/new?group_id=41) is a great place to start.
+  * If you **access** an opportunity through Enspiral, set it up to contribute back to the network in some way e.g. become an Enspiral Services contributor, contract Enspiral Ventures to work on it.
 
-  * If you access an opportunity through Enspiral, set it up to contribute back to the network in some way e.g. become an Enspiral Services contributor, contract Enspiral Ventures to work on it.
+  * **Learn** about our social mission and [uphold our values](https://enspiral.gitbooks.io/enspiral-handbook/content/values.html).
 
-  * Learn about our social mission and [uphold our values](https://enspiral.gitbooks.io/enspiral-handbook/content/values.html).
+**Encouraged:**
 
-Encouraged :
+  * **Attend** Enspiral [retreats](http://www.festival.enspiral.com/) and events
 
-  * Attend Enspiral retreats and events
+  * **Propose buckets** in [Cobudget](http://enspiral.us1.list-manage1.com/track/click?u=62b0ebd5c3dbb30bced6e6cf9&id=7ec3a82a55&e=7add41283b), and work on other’s projects
 
-  * Host events, share your knowledge and skills through our [Chalkle channel](https://chalkle.com/enspiral)
+  * **Refer opportunities** to Enspiral people and ventures
 
-  * Propose buckets in [Cobudget](http://enspiral.us1.list-manage1.com/track/click?u=62b0ebd5c3dbb30bced6e6cf9&id=7ec3a82a55&e=7add41283b), and work on other’s projects
+  * **Respond** to invitations to participate in network initiatives and contribute to setting the direction of the network
+  
+  * **Do commercial work** through ventures in the network to enhance your livelihood and that of others
 
-  * Refer opportunities to Enspiral people and ventures
-
-  * Respond to invitations to participate in network initiatives and contribute to setting the direction of the network
-  * Do commercial work through ventures in the network to enhance your livelihood and that of others
-
-Got some thoughts on this? For more background on [this agreement] and to ask questions, see [this Loomio discussion](https://www.loomio.org/d/N2DF7PeQ/-refactor-people-agreement).
+**Got some thoughts on this? For more background on [this agreement] and to ask questions, see [this Loomio discussion](https://www.loomio.org/d/N2DF7PeQ/-refactor-people-agreement).**
 
 Happy contributing!
 
 Enspiral Foundation
 
-## Week 4: Getting informed about Enspiral**
+## Week 4: Getting informed about Enspiral
 Kia ora
-Hungry to get more informed about Enspiral?
+**Hungry to get more informed about Enspiral?**
 We have a multitude of places you can delve into to understand more about the network. Here’s some we can recommend ＼(^o^)／
 
-### Read :
+### Read:
 
 [Enspiral Handbook](handbook.enspiral.com) - a work in progress guide to being part of Enspiral
 
 [Enspiral Tales](https://medium.com/enspiral-tales) on Medium - our blog with many diverse authors
 
-[Namaste Foundation blog](http://www.namaste.org/) - posts about / by Enspiral
+[Enspiral FAQ](http://www.enspiral.com/faq/) - our answers to your questions. [Submit more here](https://github.com/enspiral/guides/blob/master/faq.md).
 
-Enspiral FAQ - our answers to your questions. Submit more here.
-
-### Watch :
+### Watch:
 [Enspiral YouTube channel](https://www.youtube.com/user/enspiral)
 
-### Ask :
+### Ask:
 [Ask Enspiral](https://www.loomio.org/g/9G8VrBKv/enspiral-enspiral-opportunities-ask-enspiral) group on Loomio
 
 ### Enspiral_help channel on Slack
-We really encourage question-asking at Enspiral. It helps us understand what is clear and what isn’t. So please never hesitate to jump on to Loomio or Slack and ask away!
+
+**We really encourage question-asking at Enspiral. It helps us understand what is clear and what isn’t. So please never hesitate to jump on to Loomio or Slack and ask away!**
 
 Happy exploring!
 
-## Week 5: Getting active in Enspiral**
+## Week 5: Getting active in Enspiral
 Kia ora
-Time to get active!
-Hopefully by now you’re getting an understanding of the Enspiral beast and are ready to start being an active citizen in our community! Here’s some actions we encourage new Contributors to take.
+**Time to get active!**
+Hopefully by now you’re getting an understanding of the Enspiral spaghetti and are ready to start being an active citizen in our community! **Here’s some actions we encourage new Contributors to take.**
 
-Add your voice to a Loomio discussion happening in the Enspiral Group. Vote in as many decisions as you can - even if you are Abstaining because you don’t have enough context, it’s still valuable participation.
+**Add your voice to a Loomio discussion** happening in the Enspiral Group. Vote in as many decisions as you can - even if you are Abstaining because you don’t have enough context, it’s still valuable participation.
 
-Propose or help shape an idea by commenting on Cobudget. Maybe you’ve got fresh insights as to how we can make coming into the network better for other people or some other brainwave of how to contribute to the network. Putting up a bucket on Cobudget is the best way to gather people and funds behind your idea.
+**Propose or help shape an idea by commenting on Cobudget.** Maybe you’ve got fresh insights as to how we can make coming into the network better for other people or some other brainwave of how to contribute to the network. Putting up a bucket on Cobudget is the best way to gather people and funds behind your idea.
 
-Post in Slack, Facebook or Hylo - choose your favourite casual discussion channel and share some inspiration, a question, an idea. Make sure you’ve completed your profile on these platforms so others will know what your passions and focus areas are!
+**Post in Slack, Loomio or Facebook** - choose your favourite casual discussion channel and share some inspiration, a question, an idea. Make sure you’ve completed your profile on these platforms so others will know what your passions and focus areas are!
 
-Come to an Enspiral Retreat (held every 6 months) or an event posted on our Chalkle channel.
+**Take up a challenge** in the [Activation Program(me)](/guides/activation-programme.html) - This aims to support new contributors to become quickly active in the community through a "learning by doing" process. It consists in completing a list of easy / intermediate / hard challenges that will help any new contributor know more about Enspiral processes, people and culture.
 
-Take part in a Project Kitchen - a fast and fun way to collaboratively problem-solve on some of the multitude of projects happening in the network. Check the #project_kitchen channel on Slack for upcoming kitchens or put in a request for one to happen!
+**Come to an [Enspiral Retreat](http://www.festival.enspiral.com/)** (held every six months). Annually is Summer Festival – a combination of high energy, socially engaging and mentally stimulating experiences as well as a chance to slow down, explore deep conversations, and reflect on your purpose and direction. The result is the unique combination of work and play that we call Enspiral!
+
 Happy engaging!
-
 
 ## Week 6: Tell us how you’re going**
 Kia ora
-Tell us how it's been! A piece of cake? Or something else?
 
-At Enspiral we’re constantly working to improve the experience of people in the network in being able to meaningfully participate in our mission of ‘more people working on stuff that matters’ and gain impactful livelihood through involvement in our community.
+**Tell us how it's been! A piece of cake? Or something else?**
 
-You’re now halfway through your 3 month trial and we’d love to understand how your experience has been - what’s been valuable and what hasn’t, what’s clear and what’s confusing, and your ideas for improving this on-ramp into Enspiral.
+At Enspiral we’re constantly working to improve the experience of people in the network in being able to meaningfully participate in our mission of ‘more people working on stuff that matters’ and cultivate an impactful livelihood through involvement in our community.
+
+You’re now halfway through your three month trial and we’d love to understand how your experience has been - what’s been valuable and what hasn’t, what’s clear and what’s confusing, and your ideas for improving this on-ramp into Enspiral.
 
 
 Please fill in this [Google Form](https://docs.google.com/a/enspiral.com/forms/d/e/1FAIpQLSdxjSG-2E_YFUIEwOzO3A7dt1OuY5dOxArVgpdcy5nPDvAkgw/viewform?c=0&w=1) to help us out

--- a/guides/ops_processes.md
+++ b/guides/ops_processes.md
@@ -64,3 +64,32 @@ Ops removes the Contributor’s accounts from the following Enspiral systems:
 - Slack: (Note: you cannot fully “remove” users, instead the Contributor’s account is “disabled”)
 
 If the Contributor has a Google Apps account (a "name@enspiral.com" account), they are notified via email and Slack that their Google Apps account will be removed in two weeks. Ops schedules the Google Apps account removal date. After two weeks, the account is removed and any remaining Google Drive documents owned by the contributor is re-assigned to a nominated account managed by Ops. If the Contributor is also in a Venture, Ops updates the repeating invoices to the Venture for the Google Apps account.
+
+##Cobudget Processes
+
+Ops is working with the Greaterthan team to deliver the collaborative funding for the network through Cobudget. Cobudget is currently run in monthly funding rounds. The following is a detailed description of the operational processes that back up the action on Cobudget and in the Enspiral Foundation bank accounts. (Contributors only: view [this Loomio discussion](https://www.loomio.org/d/DbW3nipl/it-s-time-facilitated-cobudget-) for the latest discussion about collaborative funding rounds.)
+
+Enspiral Foundation has a dedicated "Collab Funding" bank account, which houses the "real money" total amount for all of the funds circulating in the Cobudget platform. Ops runs a spreadsheet database in collaboration with Greaterthan as a bridge between Cobudget and the banka account. While Cobudget continues to be developed, the total funds in the Collab Funding bank account is comprised of the following allocations/breakdown of this total in Cobudget:
+
+* **Available Funds** - this appears at the top of the screen and shows the total unspent funds in your individual account. The figure to the right of this shows the total 'unspent funds' for the whole group, including: unspent funds in all individual accounts, including invited users with funds.
+* **Total Incomplete** - this is the total value of funded incomplete buckets
+* **"Funded Now" Total in "Funding" Buckets** - this is the total amount of funds that have been allocated to "Funding" buckets
+* **Completed Unpaid Buckets** - this is the total amount of funds sitting in "Completed" but "Unpaid" buckets, that is buckets that haven't been paid out with real money from the Collab Funding bank account.
+
+Not all of the above is clearly represented at present in Cobudget. As such, Ops and Greaterthan uses a spreadsheet to track the total funds in Cobudget vs. the total in the Collab Funding bank account.
+
+#How funds enter Cobudget
+Contributors can allocate funds to their individual Cobudget account as part of the annual Opt-in process or via the  [Variable contributions](https://handbook.enspiral.com/finances_variable_contributions.html) form. For tax purposes, **Variable contributions** are treated differently than the funds allocated as part of annual Opt-ins. (View the above link for further details about this). 
+
+Once this money is received in the Enspiral Foundation bank account, Ops reconciles the bank payment in Xero and adds a record of this payment to the Cobudget "Audit log". This list of users and Cobudget contributions in the Audit Log are queued up for the subsequent funding round. At the start of a funding round, these funds are added to individual contributor accounts. Ventures also make contributions to Cobudget to team accounts; these payments are similarly recorded into this audit log.
+
+#General funding round process
+* At the start of a funding round: Greaterthan enter Funded Buckets from the previous round into the Cobudget spreadsheet dashboard.
+* Ops receives a notification that there is a new Funded Bucket
+* Once the bucket details are entered in the spreadsheet, an email is then sent to the bucket owner with instructions on how to invoice Enspiral Foundation. (Specifically this email is triggered from a Zap based on the "Status" column of the row). The invoice must include: the total amount for the bucket (remember, the amounts in Cobudget are GST-exclusive), bucket name and URL, a clear indication of whether GST is included in your invoice, and the recipient's bank account number.
+* The bucket owner sends the invoice to Foundation and Ops enters this in Xero as a bill for payment.
+* The 'real money' payment is made from the Collab Funding account to the recipient and Ops changes the status of the bucket in the spreadsheet to 'Paid' and records any necessary comments. The bucket balance total in this spreadsheet is reduced accordingly. 
+* Simultaneously, at the start of a funding round, Greaterthan add funds from the Audit Log list of queued funds to individual's accounts.
+* Once Greaterthan have confirmed that funds have been allocated, Ops audits the total in Cobudget with the spreadsheet dashboard and makes a once-monthly transfer in/out of the Collab-funding account to/from the Invoices/Expenses account or Reserves.
+* Greaterthan facilitates and opens the new funding round and the above process repeats at the end/beginning of the next cycle.
+* Ops marks the bucket in Cobudget as 'Completed'.

--- a/guides/ops_processes.md
+++ b/guides/ops_processes.md
@@ -78,12 +78,12 @@ Enspiral Foundation has a dedicated "Collab Funding" bank account, which houses 
 
 Not all of the above is clearly represented at present in Cobudget. As such, Ops and Greaterthan uses a spreadsheet to track the total funds in Cobudget vs. the total in the Collab Funding bank account.
 
-#How funds enter Cobudget
+###How funds enter Cobudget
 Contributors can allocate funds to their individual Cobudget account as part of the annual Opt-in process or via the  [Variable contributions](https://handbook.enspiral.com/finances_variable_contributions.html) form. For tax purposes, **Variable contributions** are treated differently than the funds allocated as part of annual Opt-ins. (View the above link for further details about this). 
 
 Once this money is received in the Enspiral Foundation bank account, Ops reconciles the bank payment in Xero and adds a record of this payment to the Cobudget "Audit log". This list of users and Cobudget contributions in the Audit Log are queued up for the subsequent funding round. At the start of a funding round, these funds are added to individual contributor accounts. Ventures also make contributions to Cobudget to team accounts; these payments are similarly recorded into this audit log.
 
-#General funding round process
+###General funding round process
 * At the start of a funding round: Greaterthan enter Funded Buckets from the previous round into the Cobudget spreadsheet dashboard.
 * Ops receives a notification that there is a new Funded Bucket
 * Once the bucket details are entered in the spreadsheet, an email is then sent to the bucket owner with instructions on how to invoice Enspiral Foundation. (Specifically this email is triggered from a Zap based on the "Status" column of the row). The invoice must include: the total amount for the bucket (remember, the amounts in Cobudget are GST-exclusive), bucket name and URL, a clear indication of whether GST is included in your invoice, and the recipient's bank account number.

--- a/guides/ops_processes.md
+++ b/guides/ops_processes.md
@@ -67,29 +67,31 @@ If the Contributor has a Google Apps account (a "name@enspiral.com" account), th
 
 ##Cobudget Processes
 
-Ops is working with the Greaterthan team to deliver the collaborative funding for the network through Cobudget. Cobudget is currently run in monthly funding rounds. The following is a detailed description of the operational processes that back up the action on Cobudget and in the Enspiral Foundation bank accounts. (Contributors only: view [this Loomio discussion](https://www.loomio.org/d/DbW3nipl/it-s-time-facilitated-cobudget-) for the latest discussion about collaborative funding rounds.)
+Ops is working with the Greaterthan (GT) team to deliver collaborative funding for the network through Cobudget. Cobudget is currently run in monthly funding rounds. The following is a detailed description of the operational processes that back up the action on Cobudget and in the Enspiral Foundation bank accounts. (Contributors only: view [this Loomio discussion](https://www.loomio.org/d/DbW3nipl/it-s-time-facilitated-cobudget-) for the latest discussion about collaborative funding rounds.)
 
-Enspiral Foundation has a dedicated "Collab Funding" bank account, which houses the "real money" total amount for all of the funds circulating in the Cobudget platform. Ops runs a spreadsheet database in collaboration with Greaterthan as a bridge between Cobudget and the banka account. While Cobudget continues to be developed, the total funds in the Collab Funding bank account is comprised of the following allocations/breakdown of this total in Cobudget:
+Enspiral Foundation has a dedicated "Collab Funding" bank account, which is the "real money" that underwrites the funds circulating Cobudget. Ops runs a spreadsheet database in collaboration with GT as a bridge between Cobudget and the bank account. While Cobudget continues to be developed, the total funds in the Collab Funding  account is comprised of the following allocations/breakdown of this total in Cobudget:
 
 * **Available Funds** - this appears at the top of the screen and shows the total unspent funds in your individual account. The figure to the right of this shows the total 'unspent funds' for the whole group, including: unspent funds in all individual accounts, including invited users with funds.
 * **Total Incomplete** - this is the total value of funded incomplete buckets
 * **"Funded Now" Total in "Funding" Buckets** - this is the total amount of funds that have been allocated to "Funding" buckets
 * **Completed Unpaid Buckets** - this is the total amount of funds sitting in "Completed" but "Unpaid" buckets, that is buckets that haven't been paid out with real money from the Collab Funding bank account.
 
-Not all of the above is clearly represented at present in Cobudget. As such, Ops and Greaterthan uses a spreadsheet to track the total funds in Cobudget vs. the total in the Collab Funding bank account.
+Not all of the above is clearly represented at present in Cobudget. As such, Ops and GT use a spreadsheet to track the total funds in Cobudget vs. the total in the Collab Funding account.
 
 ###How funds enter Cobudget
+
 Contributors can allocate funds to their individual Cobudget account as part of the annual Opt-in process or via the  [Variable contributions](https://handbook.enspiral.com/finances_variable_contributions.html) form. For tax purposes, **Variable contributions** are treated differently than the funds allocated as part of annual Opt-ins. (View the above link for further details about this). 
 
 Once this money is received in the Enspiral Foundation bank account, Ops reconciles the bank payment in Xero and adds a record of this payment to the Cobudget "Audit log". This list of users and Cobudget contributions in the Audit Log are queued up for the subsequent funding round. At the start of a funding round, these funds are added to individual contributor accounts. Ventures also make contributions to Cobudget to team accounts; these payments are similarly recorded into this audit log.
 
 ###General funding round process
-* At the start of a funding round: Greaterthan enter Funded Buckets from the previous round into the Cobudget spreadsheet dashboard.
+
+* At the start of a funding round: GT enter Funded Buckets from the previous round into the Cobudget spreadsheet dashboard.
 * Ops receives a notification that there is a new Funded Bucket
-* Once the bucket details are entered in the spreadsheet, an email is then sent to the bucket owner with instructions on how to invoice Enspiral Foundation. (Specifically this email is triggered from a Zap based on the "Status" column of the row). The invoice must include: the total amount for the bucket (remember, the amounts in Cobudget are GST-exclusive), bucket name and URL, a clear indication of whether GST is included in your invoice, and the recipient's bank account number.
+* Once the bucket details are entered in the spreadsheet, an automated email is sent to the bucket owner with instructions on how to invoice Enspiral Foundation. (Specifically this email is triggered using Zapier). The invoice must include: the total amount for the bucket (Amounts in Cobudget are GST-exclusive), bucket name and URL, a clear indication of whether GST is included in your invoice, and the recipient's bank account number.
 * The bucket owner sends the invoice to Foundation and Ops enters this in Xero as a bill for payment.
 * The 'real money' payment is made from the Collab Funding account to the recipient and Ops changes the status of the bucket in the spreadsheet to 'Paid' and records any necessary comments. The bucket balance total in this spreadsheet is reduced accordingly. 
-* Simultaneously, at the start of a funding round, Greaterthan add funds from the Audit Log list of queued funds to individual's accounts.
-* Once Greaterthan have confirmed that funds have been allocated, Ops audits the total in Cobudget with the spreadsheet dashboard and makes a once-monthly transfer in/out of the Collab-funding account to/from the Invoices/Expenses account or Reserves.
-* Greaterthan facilitates and opens the new funding round and the above process repeats at the end/beginning of the next cycle.
+* Simultaneously, at the start of a funding round, GT add funds from the Audit Log list of queued funds to individual's accounts.
+* Once GT have confirmed that funds have been allocated, Ops audits the total in Cobudget with the spreadsheet dashboard and makes a once-monthly transfer in/out of the Collab-funding account to/from the Invoices/Expenses account or Reserves.
+* GT facilitates and opens the new funding round and the above process repeats at the end/beginning of the next cycle.
 * Ops marks the bucket in Cobudget as 'Completed'.


### PR DESCRIPTION
Massive pull request follows!

Summary:
- updated onboarding series page to reflect new content in mailchimp emails, including removing old stuff (chalkle, hylo) and adding in new links etc.
- added the current Cobudget processing info to the Ops Processes page
- updated the forms page to remove bucket payout request link, as this is now managed by Greaterthan
- updated the financial transparency page with the latest Oct 2017 balances; as well as the fixed budget to reflect how it's gone over the last year
- updated the collab funding page to reflect the new process facilitated by Greaterthan with a link to the Ops processes page for more detail
- updated the board page with the new board members & bios