### PR TITLE
Remove invitation to view Kumu comms explorable

### DIFF
--- a/guides/comms_guidelines.md
+++ b/guides/comms_guidelines.md
@@ -6,8 +6,6 @@ These comms channels are hosted by the Enspiral Foundation and are open to all c
 
 [![Map of our comms tools](https://i.imgur.com/GaC40ja.png)](https://kumu.io/enspiral/comms)
 
-[Explore an interactive map of our comms tools](https://kumu.io/enspiral/comms), or read on:
-
 # Comms Platforms and Tools
 
 


### PR DESCRIPTION
Seems this Kumu interactive thingy it's no longer accessible :)

![Screen Shot 2019-07-11 at 5 53 42 PM](https://user-images.githubusercontent.com/305339/61087874-e298cd00-a404-11e9-8118-eebb7c4ef599.png)

@rdbartlett is this intentional, or something that should come back? If not coming back, maybe worth doing a new screenshot and removing mention?